### PR TITLE
plugin.audio.radio_de_light fix for failing add to Meine Liste

### DIFF
--- a/plugin.audio.radio_de_light/addon.py
+++ b/plugin.audio.radio_de_light/addon.py
@@ -315,7 +315,7 @@ elif mode==5:
     MYSTATIONS()
     xbmcplugin.endOfDirectory(int(sys.argv[1]))
 elif mode==6:
-    image = params.get('image')
+    image = params.get('image') or "https://i.postimg.cc/N0MfwFNf/no-image.jpg"
     if "special://" in image:
         image = "https://i.postimg.cc/N0MfwFNf/no-image.jpg"
     ADDSTATION(url, name, image)


### PR DESCRIPTION
Since I stumbled over the same problem mentioned in 
https://github.com/Publish3r/repository.kodi.matrix/issues/9
I've had a look into the code.

I changed it so that if no station image is found, the default one is used.  Prevents the variable "image" from being "NoneType"